### PR TITLE
Implementa o controle do volume de dados no extrato em PaymentAPI

### DIFF
--- a/api/Controllers/ExtractController.cs
+++ b/api/Controllers/ExtractController.cs
@@ -22,7 +22,7 @@ public class ExtractController : ControllerBase
     {
         var movements = await _manager.GetByAccountIdAsync(accountId, viewModel.Index, viewModel.Length);
 
-        if(movements == null || movements.Count <= 1)
+        if(movements == null || movements.Count < 1)
             return NotFound($"Desculpa, não foram encontradas movimentações para conta {accountId}.");
 
         return Ok(movements);

--- a/api/Controllers/ExtractController.cs
+++ b/api/Controllers/ExtractController.cs
@@ -1,4 +1,5 @@
 using api.Interfaces;
+using api.Models.Extract;
 using Microsoft.AspNetCore.Mvc;
 
 namespace api.Controllers;
@@ -14,12 +15,12 @@ public class ExtractController : ControllerBase
         _manager = manager;
     }
 
-    [HttpGet("get/{accountId}")]
+    [HttpGet, Route("get/{accountId}")]
     [ProducesResponseType(typeof(api.Models.Movements.Movement), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetByIdAsync(int accountId, int startIndex, int extractCount)
+    public async Task<IActionResult> GetByIdAsync([FromRoute] int accountId, [FromQuery] ExtractViewModel viewModel)
     {
-        var movements = await _manager.GetByAccountIdAsync(accountId, startIndex, extractCount);
+        var movements = await _manager.GetByAccountIdAsync(accountId, viewModel.Index, viewModel.Length);
 
         if(movements == null || movements.Count <= 1)
             return NotFound($"Desculpa, não foram encontradas movimentações para conta {accountId}.");

--- a/api/Controllers/ExtractController.cs
+++ b/api/Controllers/ExtractController.cs
@@ -17,9 +17,9 @@ public class ExtractController : ControllerBase
     [HttpGet("get/{accountId}")]
     [ProducesResponseType(typeof(api.Models.Movements.Movement), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetByIdAsync(int accountId)
+    public async Task<IActionResult> GetByIdAsync(int accountId, int startIndex, int extractCount)
     {
-        var movements = await _manager.GetByAccountIdAsync(accountId);
+        var movements = await _manager.GetByAccountIdAsync(accountId, startIndex, extractCount);
 
         if(movements == null || movements.Count <= 1)
             return NotFound($"Desculpa, não foram encontradas movimentações para conta {accountId}.");

--- a/api/Interfaces/IExtractManager.cs
+++ b/api/Interfaces/IExtractManager.cs
@@ -1,8 +1,9 @@
+using api.Models.Extract;
 using api.Models.Movements;
 
 namespace api.Interfaces;
 
 public interface IExtractManager
 {
-    Task<List<string>> GetByAccountIdAsync(int accountId, int startIndex, int extractCount);
+    Task<ExtractResult> GetByAccountIdAsync(int accountId, int startIndex, int extractCount);
 }    

--- a/api/Interfaces/IExtractManager.cs
+++ b/api/Interfaces/IExtractManager.cs
@@ -4,5 +4,5 @@ namespace api.Interfaces;
 
 public interface IExtractManager
 {
-    Task<List<string>> GetByAccountIdAsync(int accountId);
+    Task<List<string>> GetByAccountIdAsync(int accountId, int startIndex, int extractCount);
 }    

--- a/api/Managers/ExtractManager.cs
+++ b/api/Managers/ExtractManager.cs
@@ -16,9 +16,16 @@ public class ExtractManager : IExtractManager
         _accountManager = accountManager;
     }
 
-    public async Task<List<string>> GetByAccountIdAsync(int accountId)
+    public async Task<List<string>> GetByAccountIdAsync(int accountId, int startIndex, int extractCount)
     {
-        var result = new List<string>();
+        int defaultValeuExtract = 10; // valor default da quantidade de itens no extrato;
+        int maximumValueExtract = 90; // valor maximo da quantidade de itens no extrato;
+
+        // Validação quantidade de itens
+        if(extractCount == 0 || extractCount == null) extractCount = defaultValeuExtract; // trata caso o valor passado seja 0 ou nulo.
+        if(extractCount >= maximumValueExtract) extractCount = maximumValueExtract; // trata caso o valor seja maior que o máximo permitido.
+
+        var query = new List<string>();
 
         var movements = await _context.Movements
                                 .Where(x => x.AccountId == accountId)
@@ -33,8 +40,14 @@ public class ExtractManager : IExtractManager
 
         foreach (var movement in movements)
         {
-            result.Add(movement.Comments);
+            query.Add(movement.Comments);
         }
+
+        // Validar indice de inicio
+        if(startIndex < 0 || startIndex == null) startIndex = 0;
+        if(startIndex > query.Count) startIndex = query.Count;
+
+        var result = query.GetRange(startIndex, extractCount);
 
         return result;
     }

--- a/api/Managers/ExtractManager.cs
+++ b/api/Managers/ExtractManager.cs
@@ -45,8 +45,12 @@ public class ExtractManager : IExtractManager
 
         // Validar indice de inicio
         if(startIndex < 0 || startIndex == null) startIndex = 0;
-        if(startIndex > query.Count) startIndex = query.Count;
-
+        if(startIndex >= query.Count)
+        {
+            var emptyList = new List<string>();
+            return emptyList;
+        }
+            
         var result = query.GetRange(startIndex, extractCount);
 
         return result;

--- a/api/Managers/TransactionsManager.cs
+++ b/api/Managers/TransactionsManager.cs
@@ -77,6 +77,7 @@ public class TransactionsManager : ITransactionsManager
             CardNumber = fourLastDigitsOfCardApproved,
             Account = query
         };
+        
         approvedTransation.NetValue = approvedTransation.GrossValue - approvedTransation.FlatRate;
 
         query.Balance = ((decimal)(query.Balance + approvedTransation.NetValue));

--- a/api/Models/Extract/ExtractResult.cs
+++ b/api/Models/Extract/ExtractResult.cs
@@ -1,0 +1,9 @@
+namespace api.Models.Extract;
+
+public class ExtractResult
+{
+    public int Index { get; set; }
+    public int Length { get; set; }
+    public List<string>? Itens  { get; set; }
+    public long Count { get; set; }
+}

--- a/api/Models/Extract/ExtractViewModel.cs
+++ b/api/Models/Extract/ExtractViewModel.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.Models.Extract;
+
+public class ExtractViewModel
+{
+    [Required, Range(0, int.MaxValue)]
+    public int Index { get; set; }
+    public int Length { get; set; }
+}

--- a/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
+++ b/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
@@ -1,6 +1,7 @@
 using api.Controllers;
 using api.Interfaces;
 using api.Models;
+using api.Models.Extract;
 using api.Models.Movements;
 using api.Models.Withdraws;
 using Microsoft.AspNetCore.Mvc;
@@ -30,6 +31,11 @@ public class ExtractControllerTest
     public async Task ShouldListByAccountId()
     {
         // Arrange
+        var mockedViewModel = new ExtractViewModel{
+            Index = 0,
+            Length = 5
+        };
+        
         var id = new Random().Next();
                 var account = new Account{
             Id = 1,
@@ -126,7 +132,7 @@ public class ExtractControllerTest
         var extractController = new ExtractController(manager.Object);
 
         // Act
-        var result = (OkObjectResult)await extractController.GetByIdAsync(id, 0, 5);
+        var result = (OkObjectResult)await extractController.GetByIdAsync(id, mockedViewModel);
 
         // Assert
         Assert.Equal(200, result.StatusCode);

--- a/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
+++ b/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
@@ -74,23 +74,59 @@ public class ExtractControllerTest
             AccountId = 2
         };
 
+        var movement4 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
         account.Movements.Add(movement1);
         account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
 
         _context.Accounts.Add(account);
         var movements = new List<string>{
+            "String genérica.",
+            "String genérica.",
+            "String genérica.",
             "String genérica.",
             "String genérica."
         };
         await _context.SaveChangesAsync();
 
         var manager = new Mock<IExtractManager>();
-        manager.Setup(x => x.GetByAccountIdAsync(id)).ReturnsAsync(movements);
+        manager.Setup(x => x.GetByAccountIdAsync(id, 0, 5)).ReturnsAsync(movements);
 
         var extractController = new ExtractController(manager.Object);
 
         // Act
-        var result = (OkObjectResult)await extractController.GetByIdAsync(id);
+        var result = (OkObjectResult)await extractController.GetByIdAsync(id, 0, 5);
 
         // Assert
         Assert.Equal(200, result.StatusCode);

--- a/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
+++ b/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
@@ -124,10 +124,17 @@ public class ExtractControllerTest
             "String genérica.",
             "String genérica."
         };
+        var mockedResult = new ExtractResult{
+            Index = mockedViewModel.Index,
+            Length = mockedViewModel.Length,
+            Itens = movements,
+            Count = 5
+
+        };
         await _context.SaveChangesAsync();
 
         var manager = new Mock<IExtractManager>();
-        manager.Setup(x => x.GetByAccountIdAsync(id, 0, 5)).ReturnsAsync(movements);
+        manager.Setup(x => x.GetByAccountIdAsync(id, 0, 5)).ReturnsAsync(mockedResult);
 
         var extractController = new ExtractController(manager.Object);
 

--- a/test/PaymentApiTest/Validations/ExtractManagerTest.cs
+++ b/test/PaymentApiTest/Validations/ExtractManagerTest.cs
@@ -127,14 +127,11 @@ public class ExtractManagerTest
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(extractCount, result.Count);
-        Assert.All(result, 
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens, 
                     p => Assert.Equal("String genérica.", p.ToString()));
-    }
-
-    public async Task ShouldConvertExtractValue()
-    {
-
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(5, result.Count);
     }
 
     public static string CreateRandomStringBySize(int size)

--- a/test/PaymentApiTest/Validations/ExtractManagerTest.cs
+++ b/test/PaymentApiTest/Validations/ExtractManagerTest.cs
@@ -25,8 +25,18 @@ public class ExtractManagerTest
         _context.Database.EnsureCreated();
     }
 
-    [Fact]
-    public async Task ShouldListByAccountId()
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 0, 5)]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 2, 3)]
+    [InlineData(1, 3, 2)]
+    [InlineData(1, 4, 1)]
+    [InlineData(1, 5, 0)]    
+    public async Task ShouldListByAccountId(int accountId, int startIndex, int extractCount)
     {
         // Arrange
         var manager = new ExtractManager(_context, _manager);
@@ -73,20 +83,57 @@ public class ExtractManagerTest
             AccountId = 2
         };
 
+        var movement4 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
         account.Movements.Add(movement1);
         account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
 
         _context.Accounts.Add(account);
         await _context.SaveChangesAsync();
 
         // Act
-        var result = await manager.GetByAccountIdAsync(account.Id);
+        var result = await manager.GetByAccountIdAsync(accountId, startIndex, extractCount);
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(2, result.Count);
-        Assert.Equal("String genérica.", result.First().ToString());
-        Assert.Equal("String genérica.", result.Last().ToString());
+        Assert.Equal(extractCount, result.Count);
+        Assert.All(result, 
+                    p => Assert.Equal("String genérica.", p.ToString()));
+    }
+
+    public async Task ShouldConvertExtractValue()
+    {
 
     }
 


### PR DESCRIPTION
_**História correspondente**_: https://dev.azure.com/paggcerto/Development/_sprints/taskboard/Development%20Team/Development/Sprint%2054?workitem=6392
Implementa o **controle do volume de dados** nos extratos requeridos em _PaymentAPI_. Agora, ao solicitar o extrato, o usuário  informa:
- Id da conta,
- Quantos extratos deseja "pular",
- Quantidade de dados.

Cabe alertar que os valores passam por validações que os mantém num intevalo, pré-definido.