### PR TITLE
Implementa filtros de extrato em PaymentAPI

### DIFF
--- a/api/Controllers/ExtractController.cs
+++ b/api/Controllers/ExtractController.cs
@@ -18,9 +18,9 @@ public class ExtractController : ControllerBase
     [HttpGet, Route("get/{accountId}")]
     [ProducesResponseType(typeof(api.Models.Movements.Movement), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetByIdAsync([FromRoute] int accountId, [FromQuery] ExtractViewModel viewModel)
+    public async Task<IActionResult> GetByIdAsync([FromRoute]int accountId, [FromQuery] ExtractViewModel viewModel)
     {
-        var movements = await _manager.GetByAccountIdAsync(accountId, viewModel.Index, viewModel.Length);
+        var movements = await _manager.GetByAccountIdAsync(viewModel, accountId);
 
         if(movements == null || movements.Count < 1)
             return NotFound($"Desculpa, não foram encontradas movimentações para conta {accountId}.");

--- a/api/Interfaces/IExtractManager.cs
+++ b/api/Interfaces/IExtractManager.cs
@@ -5,5 +5,5 @@ namespace api.Interfaces;
 
 public interface IExtractManager
 {
-    Task<ExtractResult> GetByAccountIdAsync(int accountId, int startIndex, int extractCount);
+    Task<ExtractResult> GetByAccountIdAsync(ExtractViewModel viewModel, int accountId);
 }    

--- a/api/Managers/ExtractManager.cs
+++ b/api/Managers/ExtractManager.cs
@@ -17,24 +17,53 @@ public class ExtractManager : IExtractManager
         _accountManager = accountManager;
     }
 
-    public async Task<ExtractResult> GetByAccountIdAsync(int accountId, int index, int length)
+    public Task<ExtractResult> GetByAccountIdAsync(ExtractViewModel viewModel, int accountId)
     {
-        int defaultValeuExtract = 10; // valor default da quantidade de itens no extrato;
-        int maximumValueExtract = 90; // valor maximo da quantidade de itens no extrato;
+        int defaultValeuExtract = 60;
+        int maximumValueExtract = 90;
 
-        // Validação quantidade de itens
-        if(length == 0 || length == null) length = defaultValeuExtract; // trata caso o valor passado seja 0 ou nulo.
-        if(length >= maximumValueExtract) length = maximumValueExtract; // trata caso o valor seja maior que o máximo permitido.
+        if(viewModel.Length == 0 || viewModel.Length == 0) viewModel.Length = defaultValeuExtract;
+        if(viewModel.Length >= maximumValueExtract) viewModel.Length = maximumValueExtract;
     
-
         try
         {
-            var query = new List<string>();
+            if(viewModel.JustIn == true)
+            {
+                var resultIn = TakeJustIn(accountId, viewModel);
 
-            var movements = await _context.Movements
+                return resultIn;
+            }
+
+            if(viewModel.JustOut == true)
+            {
+                var resultOut = TakeJustOut(accountId, viewModel);
+
+                return resultOut;
+            }
+
+            var result = Take(accountId, viewModel);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            throw new ApplicationException("Exception thrown");
+        }
+    }
+
+    public async Task<ExtractResult> TakeJustIn(int accountId, ExtractViewModel viewModel)
+    {
+        var query = new List<string>();
+
+        var count = await _context.Movements
+                                        .Where(x => x.AccountId == accountId)
+                                        .LongCountAsync();
+
+        var movements = await _context.Movements
                                 .Where(x => x.AccountId == accountId)
-                                .Skip(index)
-                                .Take(length)
+                                .Where(x => x.Comments.Contains("entrada"))
+                                .Skip(viewModel.Index)
+                                .Take(viewModel.Length)
                                 .Select(x => new MovementResult{
                                     Id = x.Id,
                                     AccountId = x.AccountId,
@@ -44,29 +73,97 @@ public class ExtractManager : IExtractManager
                                 })
                                 .ToListAsync();
 
-            foreach (var movement in movements)
-            {
+        foreach (var movement in movements)
+        {
                 query.Add(movement.Comments);
-            }
+        }
 
-            var count = await _context.Movements
+        await _context.SaveChangesAsync();
+
+        var resultIn = new ExtractResult{
+        Index = viewModel.Index,
+        Length = viewModel.Length,
+        Itens = query,
+        Count = count
+        };
+
+        return resultIn;
+    }
+
+    public async Task<ExtractResult> TakeJustOut(int accountId, ExtractViewModel viewModel)
+    {
+        var query = new List<string>();
+
+        var count = await _context.Movements
                                         .Where(x => x.AccountId == accountId)
                                         .LongCountAsync();
 
-            var result = new ExtractResult{
-                Index = index,
-                Length = length,
-                Itens = query,
-                Count = count
-            };
+        var movements = await _context.Movements
+                                .Where(x => x.AccountId == accountId)
+                                .Where(x => x.Comments.Contains("saída"))
+                                .Skip(viewModel.Index)
+                                .Take(viewModel.Length)
+                                .Select(x => new MovementResult{
+                                    Id = x.Id,
+                                    AccountId = x.AccountId,
+                                    Date = x.Date,
+                                    Value = x.Value,
+                                    Comments = x.Comments
+                                })
+                                .ToListAsync();
 
-            return result;
-        }
-        catch (Exception ex)
+        foreach (var movement in movements)
         {
-            throw new ApplicationException("Exception thrown");
+                query.Add(movement.Comments);
         }
 
+        await _context.SaveChangesAsync();
 
+        var resultOut = new ExtractResult{
+        Index = viewModel.Index,
+        Length = viewModel.Length,
+        Itens = query,
+        Count = count
+        };
+
+        return resultOut;
+    }
+
+    public async Task<ExtractResult> Take(int accountId, ExtractViewModel viewModel)
+    {
+        var query = new List<string>();
+
+        var count = await _context.Movements
+                                        .Where(x => x.AccountId == accountId)
+                                        .LongCountAsync();
+
+        var movements = await _context.Movements
+                                .Where(x => x.AccountId == accountId)
+                                .Skip(viewModel.Index)
+                                .Take(viewModel.Length)
+                                .Select(x => new MovementResult{
+                                    Id = x.Id,
+                                    AccountId = x.AccountId,
+                                    Date = x.Date,
+                                    Value = x.Value,
+                                    Comments = x.Comments
+                                })
+                                .ToListAsync();
+
+        foreach (var movement in movements)
+        {
+                query.Add(movement.Comments);
+        }
+        
+        await _context.SaveChangesAsync();
+
+        var result = new ExtractResult{
+        Index = viewModel.Index,
+        Length = viewModel.Length,
+        Itens = query,
+        Count = count
+        };
+
+        return result;
     }
 }

--- a/api/Managers/ExtractManager.cs
+++ b/api/Managers/ExtractManager.cs
@@ -67,5 +67,6 @@ public class ExtractManager : IExtractManager
             throw new ApplicationException("Exception thrown");
         }
 
+
     }
 }

--- a/api/Models/Extract/ExtractViewModel.cs
+++ b/api/Models/Extract/ExtractViewModel.cs
@@ -3,8 +3,13 @@ using System.ComponentModel.DataAnnotations;
 namespace api.Models.Extract;
 
 public class ExtractViewModel
-{
+{    
     [Required, Range(0, int.MaxValue)]
     public int Index { get; set; }
     public int Length { get; set; }
+    public bool? JustIn { get; set; }
+    public bool? JustOut { get; set; }
+    public string? StartDate { get; set; }
+    public string? EndDate { get; set; }
+    
 }

--- a/api/Models/Extract/ExtractViewModel.cs
+++ b/api/Models/Extract/ExtractViewModel.cs
@@ -9,7 +9,7 @@ public class ExtractViewModel
     public int Length { get; set; }
     public bool? JustIn { get; set; }
     public bool? JustOut { get; set; }
-    public string? StartDate { get; set; }
-    public string? EndDate { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
     
 }

--- a/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
+++ b/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
@@ -28,7 +28,7 @@ public class ExtractControllerTest
     }
 
     [Fact]
-    public async Task ShouldListByAccountId()
+    public async Task ShouldListByAccountIdJustPayments()
     {
         // Arrange
         var mockedViewModel = new ExtractViewModel{
@@ -57,7 +57,7 @@ public class ExtractControllerTest
         var movement1 = new Movement{
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
-            Comments = "String genérica.",
+            Comments = "String genérica entrada.",
             Withdraw = null,
             Payment = new Payment(),
             Account = account,
@@ -67,7 +67,7 @@ public class ExtractControllerTest
         var movement2 = new Movement{
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
-            Comments = "String genérica.",
+            Comments = "String genérica entrada.",
             Withdraw = null,
             Payment = new Payment(),
             Account = account,
@@ -87,7 +87,7 @@ public class ExtractControllerTest
         var movement4 = new Movement{
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
-            Comments = "String genérica.",
+            Comments = "String genérica entrada.",
             Withdraw = null,
             Payment = new Payment(),
             Account = account,
@@ -97,7 +97,7 @@ public class ExtractControllerTest
         var movement5 = new Movement{
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
-            Comments = "String genérica.",
+            Comments = "String genérica entrada.",
             Withdraw = null,
             Payment = new Payment(),
             Account = account,
@@ -107,7 +107,7 @@ public class ExtractControllerTest
         var movement6 = new Movement{
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
-            Comments = "String genérica.",
+            Comments = "String genérica entrada.",
             Withdraw = null,
             Payment = new Payment(),
             Account = account,
@@ -122,11 +122,257 @@ public class ExtractControllerTest
 
         _context.Accounts.Add(account);
         var movements = new List<string>{
-            "String genérica.",
-            "String genérica.",
-            "String genérica.",
-            "String genérica.",
-            "String genérica."
+            "String genérica entrada.",
+            "String genérica entrada.",
+            "String genérica entrada.",
+            "String genérica entrada.",
+            "String genérica entrada.",
+        };
+        var mockedResult = new ExtractResult{
+            Index = mockedViewModel.Index,
+            Length = mockedViewModel.Length,
+            Itens = movements,
+            Count = 5
+
+        };
+        await _context.SaveChangesAsync();
+
+        var manager = new Mock<IExtractManager>();
+        manager.Setup(x => x.GetByAccountIdAsync(mockedViewModel, id)).ReturnsAsync(mockedResult);
+
+        var extractController = new ExtractController(manager.Object);
+
+        // Act
+        var result = (OkObjectResult)await extractController.GetByIdAsync(id, mockedViewModel);
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+
+    }
+
+    [Fact]
+    public async Task ShouldListByAccountIdJustWithdraws()
+    {
+        // Arrange
+        var mockedViewModel = new ExtractViewModel{
+            Index = 0,
+            Length = 5,
+            JustIn = true,
+            JustOut = false,
+            StartDate = null,
+            EndDate = null
+        };
+        
+        var id = new Random().Next();
+                var account = new Account{
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+        
+        var movement1 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        var movements = new List<string>{
+            "String genérica saída.",
+            "String genérica saída.",
+            "String genérica saída.",
+            "String genérica saída.",
+            "String genérica saída.",
+        };
+        var mockedResult = new ExtractResult{
+            Index = mockedViewModel.Index,
+            Length = mockedViewModel.Length,
+            Itens = movements,
+            Count = 5
+
+        };
+        await _context.SaveChangesAsync();
+
+        var manager = new Mock<IExtractManager>();
+        manager.Setup(x => x.GetByAccountIdAsync(mockedViewModel, id)).ReturnsAsync(mockedResult);
+
+        var extractController = new ExtractController(manager.Object);
+
+        // Act
+        var result = (OkObjectResult)await extractController.GetByIdAsync(id, mockedViewModel);
+
+        // Assert
+        Assert.Equal(200, result.StatusCode);
+
+    }
+
+    [Fact]
+    public async Task ShouldListByAccountIdJustAll()
+    {
+        // Arrange
+        var mockedViewModel = new ExtractViewModel{
+            Index = 0,
+            Length = 5,
+            JustIn = false,
+            JustOut = false,
+            StartDate = null,
+            EndDate = null
+        };
+        
+        var id = new Random().Next();
+                var account = new Account{
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+        
+        var movement1 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saida.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        var movements = new List<string>{
+            "String genérica saída.",
+            "String genérica entrada.",
+            "String genérica saída.",
+            "String genérica saída.",
+            "String genérica entrada.",
         };
         var mockedResult = new ExtractResult{
             Index = mockedViewModel.Index,

--- a/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
+++ b/test/PaymentApiTest/Controllers/ExtractControllerTest.cs
@@ -33,7 +33,11 @@ public class ExtractControllerTest
         // Arrange
         var mockedViewModel = new ExtractViewModel{
             Index = 0,
-            Length = 5
+            Length = 5,
+            JustIn = false,
+            JustOut = false,
+            StartDate = null,
+            EndDate = null
         };
         
         var id = new Random().Next();
@@ -134,7 +138,7 @@ public class ExtractControllerTest
         await _context.SaveChangesAsync();
 
         var manager = new Mock<IExtractManager>();
-        manager.Setup(x => x.GetByAccountIdAsync(id, 0, 5)).ReturnsAsync(mockedResult);
+        manager.Setup(x => x.GetByAccountIdAsync(mockedViewModel, id)).ReturnsAsync(mockedResult);
 
         var extractController = new ExtractController(manager.Object);
 

--- a/test/PaymentApiTest/Validations/ExtractManagerTest.cs
+++ b/test/PaymentApiTest/Validations/ExtractManagerTest.cs
@@ -36,12 +36,13 @@ public class ExtractManagerTest
     [InlineData(1, 2, 3)]
     [InlineData(1, 3, 2)]
     [InlineData(1, 4, 1)]
-    [InlineData(1, 5, 0)]    
+    [InlineData(1, 5, 0)]
     public async Task ShouldListByAccountIdAllTypes(int accountId, int startIndex, int extractCount)
     {
         // Arrange
         var manager = new ExtractManager(_context, _manager);
-        var viewModel = new ExtractViewModel{
+        var viewModel = new ExtractViewModel
+        {
             Index = startIndex,
             Length = extractCount,
             JustIn = false,
@@ -49,7 +50,8 @@ public class ExtractManagerTest
             StartDate = null,
             EndDate = null
         };
-        var account = new Account{
+        var account = new Account
+        {
             Id = 1,
             CPF = CreateRandomStringBySize(11),
             Balance = 5000m,
@@ -61,8 +63,9 @@ public class ExtractManagerTest
             Payments = new List<Payment>(),
             Movements = new List<Movement>()
         };
-        
-        var movement1 = new Movement{
+
+        var movement1 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -72,7 +75,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement2 = new Movement{
+        var movement2 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -82,7 +86,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement3 = new Movement{
+        var movement3 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -92,7 +97,8 @@ public class ExtractManagerTest
             AccountId = 2
         };
 
-        var movement4 = new Movement{
+        var movement4 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -102,7 +108,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement5 = new Movement{
+        var movement5 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -112,7 +119,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement6 = new Movement{
+        var movement6 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -137,7 +145,7 @@ public class ExtractManagerTest
         // Assert
         Assert.NotNull(result);
         Assert.Equal(extractCount, result.Itens.Count);
-        Assert.All(result.Itens, 
+        Assert.All(result.Itens,
                     p => Assert.Equal("String genérica.", p.ToString()));
         Assert.Equal(startIndex, result.Index);
         Assert.Equal(5, result.Count);
@@ -153,12 +161,13 @@ public class ExtractManagerTest
     [InlineData(1, 2, 3)]
     [InlineData(1, 3, 2)]
     [InlineData(1, 4, 1)]
-    [InlineData(1, 5, 0)]    
+    [InlineData(1, 5, 0)]
     public async Task ShouldListByAccountIdJustPayments(int accountId, int startIndex, int extractCount)
     {
         // Arrange
         var manager = new ExtractManager(_context, _manager);
-        var viewModel = new ExtractViewModel{
+        var viewModel = new ExtractViewModel
+        {
             Index = startIndex,
             Length = extractCount,
             JustIn = true,
@@ -166,7 +175,8 @@ public class ExtractManagerTest
             StartDate = null,
             EndDate = null
         };
-        var account = new Account{
+        var account = new Account
+        {
             Id = 1,
             CPF = CreateRandomStringBySize(11),
             Balance = 5000m,
@@ -178,8 +188,9 @@ public class ExtractManagerTest
             Payments = new List<Payment>(),
             Movements = new List<Movement>()
         };
-        
-        var movement1 = new Movement{
+
+        var movement1 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - entrada.",
@@ -189,7 +200,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement2 = new Movement{
+        var movement2 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - entrada.",
@@ -199,7 +211,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement3 = new Movement{
+        var movement3 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -209,7 +222,8 @@ public class ExtractManagerTest
             AccountId = 2
         };
 
-        var movement4 = new Movement{
+        var movement4 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - entrada.",
@@ -219,7 +233,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement5 = new Movement{
+        var movement5 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - entrada.",
@@ -229,7 +244,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement6 = new Movement{
+        var movement6 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - entrada.",
@@ -254,7 +270,7 @@ public class ExtractManagerTest
         // Assert
         Assert.NotNull(result);
         Assert.Equal(extractCount, result.Itens.Count);
-        Assert.All(result.Itens, 
+        Assert.All(result.Itens,
                     p => Assert.Equal("String genérica - entrada.", p.ToString()));
         Assert.Equal(startIndex, result.Index);
         Assert.Equal(5, result.Count);
@@ -270,12 +286,13 @@ public class ExtractManagerTest
     [InlineData(1, 2, 3)]
     [InlineData(1, 3, 2)]
     [InlineData(1, 4, 1)]
-    [InlineData(1, 5, 0)]    
+    [InlineData(1, 5, 0)]
     public async Task ShouldListByAccountIdJustWithdraws(int accountId, int startIndex, int extractCount)
     {
         // Arrange
         var manager = new ExtractManager(_context, _manager);
-        var viewModel = new ExtractViewModel{
+        var viewModel = new ExtractViewModel
+        {
             Index = startIndex,
             Length = extractCount,
             JustIn = false,
@@ -283,7 +300,8 @@ public class ExtractManagerTest
             StartDate = null,
             EndDate = null
         };
-        var account = new Account{
+        var account = new Account
+        {
             Id = 1,
             CPF = CreateRandomStringBySize(11),
             Balance = 5000m,
@@ -295,8 +313,9 @@ public class ExtractManagerTest
             Payments = new List<Payment>(),
             Movements = new List<Movement>()
         };
-        
-        var movement1 = new Movement{
+
+        var movement1 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - saída.",
@@ -306,7 +325,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement2 = new Movement{
+        var movement2 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - saída.",
@@ -316,7 +336,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement3 = new Movement{
+        var movement3 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica.",
@@ -326,7 +347,8 @@ public class ExtractManagerTest
             AccountId = 2
         };
 
-        var movement4 = new Movement{
+        var movement4 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - saída.",
@@ -336,7 +358,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement5 = new Movement{
+        var movement5 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - saída.",
@@ -346,7 +369,8 @@ public class ExtractManagerTest
             AccountId = account.Id
         };
 
-        var movement6 = new Movement{
+        var movement6 = new Movement
+        {
             Date = DateTime.UtcNow,
             Value = (decimal)1500m,
             Comments = "String genérica - saída.",
@@ -371,11 +395,498 @@ public class ExtractManagerTest
         // Assert
         Assert.NotNull(result);
         Assert.Equal(extractCount, result.Itens.Count);
-        Assert.All(result.Itens, 
+        Assert.All(result.Itens,
                     p => Assert.Equal("String genérica - saída.", p.ToString()));
         Assert.Equal(startIndex, result.Index);
         Assert.Equal(5, result.Count);
     }
+
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    public async Task ShouldListByAccountIdByStartDate(int accountId, int startIndex, int extractCount)
+    {
+        // Arrange
+        var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel
+        {
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = false,
+            JustOut = false,
+            StartDate = DateTime.UtcNow,
+            EndDate = null
+        };
+        var account = new Account
+        {
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+
+        var dateString = "5/1/2008 8:30:52 AM";
+        var parsedDate = DateTime.Parse(dateString);
+
+        var movement1 = new Movement
+        {
+            Date = parsedDate,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement
+        {
+            Date = DateTime.UtcNow.AddDays(3),
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens,
+                    p => Assert.Equal("String genérica - saída.", p.ToString()));
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(extractCount, result.Itens.Count);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    public async Task ShouldListByAccountIdByEndDate(int accountId, int startIndex, int extractCount)
+    {
+        // Arrange
+        var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel
+        {
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = false,
+            JustOut = false,
+            StartDate = null,
+            EndDate = DateTime.UtcNow.AddDays(2)
+        };
+        var account = new Account
+        {
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+
+        var dateString = "12/30/2022 8:30:52 AM";
+        var parsedDate = DateTime.Parse(dateString);
+
+        var movement1 = new Movement
+        {
+            Date = parsedDate,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens,
+                    p => Assert.Equal("String genérica - saída.", p.ToString()));
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(extractCount, result.Itens.Count);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 0, 5)]
+    public async Task ShouldListByAccountIdByStartDateAndEndDate(int accountId, int startIndex, int extractCount)
+    {
+        // Arrange
+        var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel
+        {
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = false,
+            JustOut = false,
+            StartDate = DateTime.UtcNow,
+            EndDate = DateTime.UtcNow.AddDays(3)
+        };
+        var account = new Account
+        {
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+
+
+        var movement1 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement
+        {
+            Date = DateTime.UtcNow.AddDays(3),
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens,
+                    p => Assert.Equal("String genérica - saída.", p.ToString()));
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(extractCount, result.Itens.Count);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 0, 5)]
+    public async Task ShouldListByAccountIdByAllFilters(int accountId, int startIndex, int extractCount)
+    {
+        // Arrange
+        var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel
+        {
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = true,
+            JustOut = false,
+            StartDate = DateTime.UtcNow,
+            EndDate = DateTime.UtcNow.AddDays(3)
+        };
+        var account = new Account
+        {
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+
+
+        var movement1 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement
+        {
+            Date = DateTime.UtcNow.AddDays(3),
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement
+        {
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens,
+                    p => Assert.Equal("String genérica - entrada.", p.ToString()));
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(extractCount, result.Itens.Count);
+    }
+
     
     public static string CreateRandomStringBySize(int size)
     {

--- a/test/PaymentApiTest/Validations/ExtractManagerTest.cs
+++ b/test/PaymentApiTest/Validations/ExtractManagerTest.cs
@@ -1,6 +1,7 @@
 using api.Interfaces;
 using api.Managers;
 using api.Models;
+using api.Models.Extract;
 using api.Models.Movements;
 using api.Models.Withdraws;
 using Microsoft.EntityFrameworkCore;
@@ -36,10 +37,18 @@ public class ExtractManagerTest
     [InlineData(1, 3, 2)]
     [InlineData(1, 4, 1)]
     [InlineData(1, 5, 0)]    
-    public async Task ShouldListByAccountId(int accountId, int startIndex, int extractCount)
+    public async Task ShouldListByAccountIdAllTypes(int accountId, int startIndex, int extractCount)
     {
         // Arrange
         var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel{
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = false,
+            JustOut = false,
+            StartDate = null,
+            EndDate = null
+        };
         var account = new Account{
             Id = 1,
             CPF = CreateRandomStringBySize(11),
@@ -123,7 +132,7 @@ public class ExtractManagerTest
         await _context.SaveChangesAsync();
 
         // Act
-        var result = await manager.GetByAccountIdAsync(accountId, startIndex, extractCount);
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
 
         // Assert
         Assert.NotNull(result);
@@ -134,6 +143,240 @@ public class ExtractManagerTest
         Assert.Equal(5, result.Count);
     }
 
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 0, 5)]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 2, 3)]
+    [InlineData(1, 3, 2)]
+    [InlineData(1, 4, 1)]
+    [InlineData(1, 5, 0)]    
+    public async Task ShouldListByAccountIdJustPayments(int accountId, int startIndex, int extractCount)
+    {
+        // Arrange
+        var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel{
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = true,
+            JustOut = false,
+            StartDate = null,
+            EndDate = null
+        };
+        var account = new Account{
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+        
+        var movement1 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - entrada.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens, 
+                    p => Assert.Equal("String genérica - entrada.", p.ToString()));
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(5, result.Count);
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0, 2)]
+    [InlineData(1, 0, 3)]
+    [InlineData(1, 0, 4)]
+    [InlineData(1, 0, 5)]
+    [InlineData(1, 1, 1)]
+    [InlineData(1, 2, 3)]
+    [InlineData(1, 3, 2)]
+    [InlineData(1, 4, 1)]
+    [InlineData(1, 5, 0)]    
+    public async Task ShouldListByAccountIdJustWithdraws(int accountId, int startIndex, int extractCount)
+    {
+        // Arrange
+        var manager = new ExtractManager(_context, _manager);
+        var viewModel = new ExtractViewModel{
+            Index = startIndex,
+            Length = extractCount,
+            JustIn = false,
+            JustOut = true,
+            StartDate = null,
+            EndDate = null
+        };
+        var account = new Account{
+            Id = 1,
+            CPF = CreateRandomStringBySize(11),
+            Balance = 5000m,
+            HolderName = "Breno Santos Barroso",
+            Agency = CreateRandomStringBySize(5),
+            IsActive = true,
+            AccountNumber = CreateRandomStringBySize(7),
+            Withdraws = new List<Withdraw>(),
+            Payments = new List<Payment>(),
+            Movements = new List<Movement>()
+        };
+        
+        var movement1 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement2 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement3 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = new Account(),
+            AccountId = 2
+        };
+
+        var movement4 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement5 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        var movement6 = new Movement{
+            Date = DateTime.UtcNow,
+            Value = (decimal)1500m,
+            Comments = "String genérica - saída.",
+            Withdraw = null,
+            Payment = new Payment(),
+            Account = account,
+            AccountId = account.Id
+        };
+
+        account.Movements.Add(movement1);
+        account.Movements.Add(movement2);
+        account.Movements.Add(movement4);
+        account.Movements.Add(movement5);
+        account.Movements.Add(movement6);
+
+        _context.Accounts.Add(account);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await manager.GetByAccountIdAsync(viewModel, accountId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(extractCount, result.Itens.Count);
+        Assert.All(result.Itens, 
+                    p => Assert.Equal("String genérica - saída.", p.ToString()));
+        Assert.Equal(startIndex, result.Index);
+        Assert.Equal(5, result.Count);
+    }
+    
     public static string CreateRandomStringBySize(int size)
     {
         var chars = "0123456789";
@@ -144,4 +387,5 @@ public class ExtractManagerTest
                     .ToArray());
         return result;
     }
+
 }


### PR DESCRIPTION
_**História correspondente**_:https://dev.azure.com/paggcerto/Development/_sprints/taskboard/Development%20Team/Development/Sprint%2055?workitem=6396
Implementa **filtros de listagem** nos extratos requeridos em _PaymentAPI_. Agora o usuário pode filtrar por:
- Somente créditos,
- Somente débitos,
- Somente a partir de uma data,
- Somente até uma data,
- Somente num intervalo de datas.

É possível combinar filtros e ainda é possível requerir extratos sem filtro algum.